### PR TITLE
feat: クイズ作成エリアのヘッダーの実装

### DIFF
--- a/src/components/atoms/SwitchButton/SwitchButton.stories.tsx
+++ b/src/components/atoms/SwitchButton/SwitchButton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { SwitchButton } from "./SwitchButton";
+import SwitchButton  from "./SwitchButton";
 import { useState } from "react";
 
 type T = typeof SwitchButton;

--- a/src/components/atoms/SwitchButton/SwitchButton.tsx
+++ b/src/components/atoms/SwitchButton/SwitchButton.tsx
@@ -3,7 +3,7 @@ type Props = {
   handleToggle: () => void;
 };
 
-export const SwitchButton = ({ isChecked = false, handleToggle }: Props) => {
+export default function SwitchButton({ isChecked = false, handleToggle }: Props) {
   return (
     <button
       type="button"

--- a/src/components/organisms/QuizBuilderHeader/QuizBuildHeader.stories.tsx
+++ b/src/components/organisms/QuizBuilderHeader/QuizBuildHeader.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import QuizBuildHeader from "./QuizBuildHeader";
+import { useQuizStore } from '@/store/useQuizStore';
+import { useState } from 'react';
+
+type T = typeof QuizBuildHeader;
+
+export default {
+  title: 'organisms/QuizBuildHeader',
+  component: QuizBuildHeader,
+} satisfies Meta<T>;
+
+export const Default: StoryObj<T> = {
+  render: () => {
+
+    const newForm = useQuizStore().newForm()
+    const { handleSubmit } = newForm
+
+    const onSubmit = () => {
+      if (isChecked) {
+        alert("公開する")
+      } else {
+        alert("保存する")
+      }
+    }
+
+    const [isChecked, setIsChecked] = useState(false);
+
+    const handleToggle = () => {
+      const newChecked = !isChecked;
+      setIsChecked(newChecked);
+    };
+
+    return (
+      <QuizBuildHeader onClickFn={handleSubmit(onSubmit)} isChecked={isChecked} handleToggle={handleToggle} />
+    )
+  }
+};

--- a/src/components/organisms/QuizBuilderHeader/QuizBuildHeader.tsx
+++ b/src/components/organisms/QuizBuilderHeader/QuizBuildHeader.tsx
@@ -1,0 +1,28 @@
+import { Button } from "@/components/atoms/Button";
+import { SwitchButton } from "@/components/atoms/SwitchButton";
+import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Link from "next/link";
+
+type Props = {
+  onClickFn: () => void;
+  isChecked: boolean;
+  handleToggle: () => void;
+}
+
+export default function QuizBuildHeader({ onClickFn, isChecked, handleToggle }: Props) {
+
+  return (
+    <div className="border-gray-300 border-b">
+      <header className="container mx-auto flex h-[70px] items-center justify-between">
+        <Link href="/home"><FontAwesomeIcon className="size-7" icon={faArrowLeft} /></Link>
+        <div className="flex items-center gap-5">
+          <SwitchButton handleToggle={handleToggle} isChecked={isChecked} />
+          <Button type="submit" size="sm" onClickFn={onClickFn}>
+            {isChecked ? "公開する": "保存する"}
+          </Button>
+        </div>
+      </header>
+    </div>
+  );
+}


### PR DESCRIPTION
## 実装内容
クイズ作成エリアのヘッダーの実装

## スクショ
<img width="1311" alt="スクリーンショット 2025-02-03 12 06 47" src="https://github.com/user-attachments/assets/1fb156c2-9a64-4580-a76b-b0a906b76533" />

## issue
close 
https://www.notion.so/1af4ef87bade4c939d121d19fc0c6a58
## 懸念点
