### PR TITLE
feat: ユーザーが投稿したクイズが一覧で見えるページの作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@hookform/resolvers": "^3.10.0",
         "@prisma/client": "^6.3.1",
         "@radix-ui/react-popover": "^1.1.5",
+        "date-fns": "^4.1.0",
         "next": "14.2.16",
         "next-auth": "^5.0.0-beta.25",
         "react": "^18",
@@ -8051,6 +8052,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@hookform/resolvers": "^3.10.0",
     "@prisma/client": "^6.3.1",
     "@radix-ui/react-popover": "^1.1.5",
+    "date-fns": "^4.1.0",
     "next": "14.2.16",
     "next-auth": "^5.0.0-beta.25",
     "react": "^18",

--- a/src/app/(pages)/quiz/my-list/page.tsx
+++ b/src/app/(pages)/quiz/my-list/page.tsx
@@ -1,0 +1,30 @@
+import MyListTemplate from "@/components/templates/myListTemplate/myListTemplate";
+import { hono } from "@/lib/hono/client";
+import { headers } from "next/headers";
+
+type SearchParams = { page: string }
+
+export default async function Page({ searchParams }: { searchParams: SearchParams }) {
+
+  const { page } = searchParams
+
+  const res = await hono.api.quzzies.mine.$get({
+    query: {
+      page: page ?? "1"
+    }
+  }, {
+    init: {
+      cache: "no-store",
+      headers: headers()
+    }
+  })
+
+  const content = await res.json()
+  const { quizzes } = content
+
+  return (
+    <>
+      <MyListTemplate quizzes={quizzes} />
+    </>
+  );
+}

--- a/src/components/organisms/QuizCard/QuizCard.stories.tsx
+++ b/src/components/organisms/QuizCard/QuizCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import QuizCard, { type Props } from "./QuizCard";
+import QuizCard from "./QuizCard";
 
 type T = typeof QuizCard;
 
@@ -12,12 +12,11 @@ export default {
 export const Public: StoryObj<T> = {
   render: () => {
 
-    const quiz: Props["quiz"] = {
+    const quiz = {
       question: "ガリレオ衛星とはイオ・エウロパ・ガニメデと何？",
-      status: "public",
       choices: [
-        { text: "" },
-        { text: "" }
+        { text: "", isCorrect: true },
+        { text: "", isCorrect: false }
       ],
       updatedAt: "2025/01/24"
     }
@@ -28,7 +27,13 @@ export const Public: StoryObj<T> = {
 
     return (
       <div className='w-[600px]'>
-        <QuizCard quiz={quiz} handleSubmit={handleSubmit} />
+        <QuizCard
+          question={quiz.question}
+          choices={quiz.choices}
+          isPublic={true}
+          updatedAt={quiz.updatedAt}
+          handleSubmit={handleSubmit}
+        />
       </div>
     )
   }
@@ -37,12 +42,11 @@ export const Public: StoryObj<T> = {
 export const Private = {
   render: () => {
 
-    const quiz: Props["quiz"] = {
+    const quiz = {
       question: "ガリレオ衛星とはイオ・エウロパ・ガニメデと何？",
-      status: "private",
       choices: [
-        { text: "" },
-        { text: "" }
+        { text: "", isCorrect: true },
+        { text: "", isCorrect: false }
       ],
       updatedAt: "2025/01/24"
     }
@@ -53,7 +57,13 @@ export const Private = {
 
     return (
       <div className='w-[600px]'>
-        <QuizCard quiz={quiz} handleSubmit={handleSubmit} />
+        <QuizCard
+          question={quiz.question}
+          choices={quiz.choices}
+          isPublic={false}
+          updatedAt={quiz.updatedAt}
+          handleSubmit={handleSubmit}
+        />
       </div>
     )
   }

--- a/src/components/organisms/QuizCard/QuizCard.tsx
+++ b/src/components/organisms/QuizCard/QuizCard.tsx
@@ -4,24 +4,24 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Popover, PopoverTrigger, PopoverContent } from "@radix-ui/react-popover";
 
 export type Props = {
-  quiz: {
-    status: "public" | "private" | undefined,
-    question: string,
-    choices: Choice[],
-    updatedAt: string
-  },
+  question: string,
+  choices: {
+    text: string;
+    isCorrect: boolean;
+  }[],
+  isPublic: boolean,
+  updatedAt: string;
   handleSubmit: () => void
 }
 
-type Choice = {
-  text: string
-}
+export default function QuizCard({ question, choices, isPublic, updatedAt, handleSubmit }: Props) {
 
-export default function QuizCard({ quiz, handleSubmit }: Props) {
+  const status = isPublic ? "public" : "private"
+
   return (
-    <div className="flex h-[130px] flex-col justify-between rounded-xl border px-6 py-5">
+    <div className="flex h-[130px] flex-col justify-between rounded-xl border border-black px-6 py-5">
       <div className="flex items-center justify-between">
-        <h3 className="text-[1.2rem]">{quiz.question}</h3>
+        <h3 className="text-[1.2rem]">{question}</h3>
         <Popover>
           <PopoverTrigger asChild>
             <button type="button">
@@ -37,10 +37,10 @@ export default function QuizCard({ quiz, handleSubmit }: Props) {
       </div>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <p className="text-[0.9rem]">選択肢数 : {quiz.choices.length}/4</p>
-          <Badge varient={quiz.status} />
+          <p className="text-[0.9rem]">選択肢数 : {choices.length}/4</p>
+          <Badge varient={status} />
         </div>
-        <p className="text-[0.9rem] text-gray-300">最終編集日：{quiz.updatedAt}</p>
+        <p className="text-[0.9rem] text-gray-300">最終編集日：{updatedAt}</p>
       </div>
     </div>
   );

--- a/src/components/templates/myListTemplate/myListTemplate.tsx
+++ b/src/components/templates/myListTemplate/myListTemplate.tsx
@@ -1,0 +1,40 @@
+"use client"
+import MyListHeader from "@/components/organisms/MyListHeader/MyListHeader";
+import { QuizCard } from "@/components/organisms/QuizCard";
+import { hono } from "@/lib/hono/client";
+import type { Quiz } from "@/server/models/quizSchema";
+import { useRouter } from "next/navigation";
+import { format } from "date-fns"
+
+export default function MyListTemplate({ quizzes }: { quizzes: Quiz[] }) {
+
+  const router = useRouter()
+
+  const handleDelete = async (quizId: string) => {
+    await hono.api.quzzies[":quizId"].$delete({
+      param: { quizId }
+    })
+
+    router.refresh()
+  }
+
+  return (
+    <div>
+      <div className="mb-[40px]">
+        <MyListHeader link="/home" />
+      </div>
+      <div className="mx-auto max-w-[700px] space-y-4">
+        {quizzes.map((quiz) => (
+          <QuizCard
+            handleSubmit={() => handleDelete(String(quiz.id))}
+            key={quiz.id}
+            question={quiz.question}
+            choices={quiz.choices}
+            isPublic={quiz.isPublic}
+            updatedAt={format(quiz.createdAt, "yyyy/MM/dd")}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/server/models/quizSchema.ts
+++ b/src/server/models/quizSchema.ts
@@ -135,3 +135,4 @@ export const UpdateQuizSchema = z.object({
 export type QuizId = z.infer<typeof QuizIdSchema>;
 export type CreateQuiz = z.infer<typeof CreateQuizSchema>;
 export type UpdateQuiz = z.infer<typeof UpdateQuizSchema>;
+export type Quiz = z.infer<typeof QuizSchema>


### PR DESCRIPTION
## 実装内容
ユーザーが投稿したクイズが一覧で見えるページの作成

## スクショ
<img width="1512" alt="スクリーンショット 2025-02-13 2 58 45" src="https://github.com/user-attachments/assets/e751e323-f826-4225-a068-79c21f5e9274" />

## issue
close 

## 懸念点
まだページネーションは実装していない。