### PR TITLE
fix: 編集画面でのトグルスイッチの挙動を修正

### DIFF
--- a/src/app/(pages)/quiz/[quizId]/edit/page.tsx
+++ b/src/app/(pages)/quiz/[quizId]/edit/page.tsx
@@ -24,7 +24,7 @@ export default async function Page({ params }: { params: { quizId: string } }) {
     notFound()
   }
 
-  const { id, question, choices } = quiz
+  const { id, question, choices, isPublic } = quiz
 
   const choicesWithLocalId = choices.map((choice, index) => ({
     ...choice,
@@ -33,7 +33,7 @@ export default async function Page({ params }: { params: { quizId: string } }) {
   
   return (
     <>
-      <EditQuizTemplate id={id} question={question} choices={choicesWithLocalId} />
+      <EditQuizTemplate id={id} question={question} choices={choicesWithLocalId} isPublic={isPublic} />
     </>
   );
 }

--- a/src/components/organisms/QuizBuilderHeader/QuizBuildHeader.tsx
+++ b/src/components/organisms/QuizBuilderHeader/QuizBuildHeader.tsx
@@ -18,9 +18,11 @@ export default function QuizBuildHeader({ onClickFn, isChecked, handleToggle }: 
         <Link href="/home"><FontAwesomeIcon className="size-7" icon={faArrowLeft} /></Link>
         <div className="flex items-center gap-5">
           <SwitchButton handleToggle={handleToggle} isChecked={isChecked} />
-          <Button type="submit" size="sm" onClickFn={onClickFn}>
-            {isChecked ? "公開する": "保存する"}
-          </Button>
+          <div className={`rounded-full ${isChecked ? "bg-green-400": "bg-white"}`}>
+            <Button type="submit" size="sm" onClickFn={onClickFn}>
+              {isChecked ? "公開する" : "保存する"}
+            </Button>
+          </div>
         </div>
       </header>
     </div>

--- a/src/components/templates/editQuizTemplate/editQuizTemplate.tsx
+++ b/src/components/templates/editQuizTemplate/editQuizTemplate.tsx
@@ -14,7 +14,7 @@ type Choice = {
   isCorrect: boolean
 }
 
-export default function EditQuizTemplate({ id, question, choices }: { id: number, question: string, choices: Choice[] }) {
+export default function EditQuizTemplate({ id, question, choices, isPublic }: { id: number, question: string, choices: Choice[], isPublic: boolean }) {
 
   const router = useRouter()
   const Form = useQuizStore().editForm({
@@ -22,7 +22,7 @@ export default function EditQuizTemplate({ id, question, choices }: { id: number
     options: choices
   })
   const { handleSubmit } = Form;
-  const [ispublished, setIsPublished] = useState(false)
+  const [ispublished, setIsPublished] = useState(isPublic)
   const handleToggle = () => {
     const newChecked = !ispublished;
     setIsPublished(newChecked);


### PR DESCRIPTION
## 実装内容
編集画面でのトグルスイッチの挙動を修正

## スクショ
公開中のものは初めから公開状態でボタンを押せるように修正
<img width="1512" alt="スクリーンショット 2025-02-14 13 11 05" src="https://github.com/user-attachments/assets/a72e2add-6700-4d3c-ae54-d2434186a27d" />

## issue
close 

## 懸念点
