### PR TITLE
feat: 前回の問題の表示画面作成と作問テキストエリアの高さを調整

### DIFF
--- a/src/app/(pages)/home/page.tsx
+++ b/src/app/(pages)/home/page.tsx
@@ -39,6 +39,7 @@ export default async function Page() {
       currentStreak={currentStreak}
       id={id}
       prevAnswer={randomQuiz.prevAnswer} 
+      prevQuizQuestion={randomQuiz.prevQuiz}
     />
   );
 }

--- a/src/components/organisms/QuizBuilder/QuizBuilder.tsx
+++ b/src/components/organisms/QuizBuilder/QuizBuilder.tsx
@@ -56,6 +56,7 @@ export default function QuizBuilder({ Form }: { Form: UseFormReturn<QuizFormData
         render={({ field }) => (
           <>
             <textarea
+              rows={1}
               {...field}
               className="min-h-[50px] w-full border-black border-b p-2 text-[1.3rem] focus:outline-none"
               placeholder="問題文"

--- a/src/components/organisms/QuizField/QuizField.tsx
+++ b/src/components/organisms/QuizField/QuizField.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ChoiceButton } from "@/components/molecules/ChoiceButton";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { hono } from "@/lib/hono/client";
 import type { Choice } from "@/server/models/choiceSchema";
 import { useRouter } from "next/navigation";
@@ -12,9 +13,10 @@ type Props = {
   choices: Choice[];
   id: number;
   prevAnswer?: string | null;
+  prevQuizQuestion?: string | null; // これは使用されていないので削除
 };
 
-export default function QuizField({ question, choices, id, prevAnswer }: Props) {
+export default function QuizField({ question, choices, id, prevAnswer, prevQuizQuestion }: Props) {
 
   const [isLoading, setIsLoading] = useState(false)
   const [selected, setSelected] = useState<string | null>(null);
@@ -72,13 +74,17 @@ export default function QuizField({ question, choices, id, prevAnswer }: Props) 
           // biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
           <div key={i} className="h-[40px]" />
         ))}
-
-        <div className="relative rounded-lg bg-yellow-300/50 p-3">
-          <div className="absolute top-0 right-0 bg-white px-3 py-1 text-xs">一個前の答え</div>
-          <div className="text-center">
-            {isLoading ? `${"判定中.."}` : prevAnswer}
-          </div>
-        </div>
+         <Accordion type="single" collapsible defaultValue="item-1">
+          <AccordionItem value="item-1">
+            <AccordionTrigger>前回の問題</AccordionTrigger>
+            <AccordionContent>
+              <div className="space-y-3 text-center">
+                <p>問題文：{isLoading ? `${"判定中.."}` : (prevQuizQuestion ?? "なし")}</p>
+                <p>正しい答え：{isLoading ? `${"判定中.."}` : (prevAnswer ?? "なし")}</p>                                
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </div>
 
     </div>

--- a/src/components/templates/homePageTemplate/homePageTemplate.tsx
+++ b/src/components/templates/homePageTemplate/homePageTemplate.tsx
@@ -10,9 +10,10 @@ type Props = {
   iconUrl: string,
   currentStreak: number,
   prevAnswer?: string | null;
+  prevQuizQuestion?: string | null;
 }
 
-export default function HomePageTemplate({ question, id, choices, iconUrl, currentStreak, prevAnswer }: Props) {
+export default function HomePageTemplate({ question, id, choices, iconUrl, currentStreak, prevAnswer, prevQuizQuestion }: Props) {
   return (
     <div className="mx-auto flex min-h-[calc(100vh-60px)] max-w-[650px] items-center justify-center px-2">
       <div className="mb-[50px] flex-1 md:mb-[90px]">
@@ -20,7 +21,7 @@ export default function HomePageTemplate({ question, id, choices, iconUrl, curre
           <StreakBubbleWithIcon iconUrl={iconUrl} streakCount={currentStreak} color="black" />
         </div>
         <div className="mb-[50px]">
-          <QuizField id={id} question={question} choices={choices} prevAnswer={prevAnswer}/>
+          <QuizField id={id} question={question} choices={choices} prevAnswer={prevAnswer} prevQuizQuestion={prevQuizQuestion} />
         </div>
         <div className="flex justify-center">
           <HomeButtons />

--- a/src/server/controllers/quiz/getRandomQuiz.ts
+++ b/src/server/controllers/quiz/getRandomQuiz.ts
@@ -48,11 +48,20 @@ export const getRandomQuizHandler: RouteHandler<typeof getRandomQuizRoute, WithA
             select: { question: true },
           })
         : null;
+      
+      const correct = await prisma.quiz.findUnique({
+        where: { id: user.prevQuizId as number },
+        include: {
+          choices: {
+            where: { isCorrect: true },
+          },
+        },
+      });
 
       const ArrangedQuiz = {
         ...quiz,
-        prevAnswer: "yes",
-        prevQuiz: prevQuiz ? prevQuiz.question : null,
+        prevAnswer: correct ? correct.choices[0].text : "問題がありません",
+        prevQuiz: prevQuiz ? prevQuiz.question : "問題がありません",
       }
 
       return c.json(ArrangedQuiz, 200);
@@ -120,7 +129,7 @@ export const getRandomQuizHandler: RouteHandler<typeof getRandomQuizRoute, WithA
   const ArrangedNewQuiz = {
     ...newQuiz,
     prevAnswer: correct ? correct.choices[0].text : "問題が削除されてしまいました。",
-    prevQuiz: prevQuiz ? prevQuiz.question : null,
+    prevQuiz: prevQuiz ? prevQuiz.question : "問題が削除されてしまいました。",
   } 
 
   return c.json(ArrangedNewQuiz, 200);

--- a/src/server/controllers/quiz/getRandomQuiz.ts
+++ b/src/server/controllers/quiz/getRandomQuiz.ts
@@ -41,10 +41,18 @@ export const getRandomQuizHandler: RouteHandler<typeof getRandomQuizRoute, WithA
       }
     });
     if (quiz) {
+      const prevQuiz =
+      user.prevQuizId
+        ? await prisma.quiz.findUnique({
+            where: { id: user.prevQuizId },
+            select: { question: true },
+          })
+        : null;
 
       const ArrangedQuiz = {
         ...quiz,
         prevAnswer: "yes",
+        prevQuiz: prevQuiz ? prevQuiz.question : null,
       }
 
       return c.json(ArrangedQuiz, 200);
@@ -101,9 +109,18 @@ export const getRandomQuizHandler: RouteHandler<typeof getRandomQuizRoute, WithA
     },
   });
 
+  const prevQuiz =
+  user.prevQuizId
+    ? await prisma.quiz.findUnique({
+        where: { id: user.prevQuizId },
+        select: { question: true },
+      })
+    : null;
+
   const ArrangedNewQuiz = {
     ...newQuiz,
     prevAnswer: correct ? correct.choices[0].text : "問題が削除されてしまいました。",
+    prevQuiz: prevQuiz ? prevQuiz.question : null,
   } 
 
   return c.json(ArrangedNewQuiz, 200);

--- a/src/server/controllers/quiz/getRandomQuiz.ts
+++ b/src/server/controllers/quiz/getRandomQuiz.ts
@@ -49,14 +49,16 @@ export const getRandomQuizHandler: RouteHandler<typeof getRandomQuizRoute, WithA
           })
         : null;
       
-      const correct = await prisma.quiz.findUnique({
-        where: { id: user.prevQuizId as number },
-        include: {
-          choices: {
-            where: { isCorrect: true },
-          },
-        },
-      });
+      const correct = 
+      user.prevQuizId
+       ? await prisma.quiz.findUnique({
+            where: { id: user.prevQuizId },
+            include: {
+              choices: {
+                where: { isCorrect: true },
+              },
+            },
+        }):null;
 
       const ArrangedQuiz = {
         ...quiz,
@@ -109,14 +111,16 @@ export const getRandomQuizHandler: RouteHandler<typeof getRandomQuizRoute, WithA
     }
   });
 
-  const correct = await prisma.quiz.findUnique({
-    where: { id: user.prevQuizId as number },
-    include: {
-      choices: {
-        where: { isCorrect: true },
-      },
-    },
-  });
+  const correct = 
+  user.prevQuizId
+      ? await prisma.quiz.findUnique({
+        where: { id: user.prevQuizId },
+        include: {
+          choices: {
+            where: { isCorrect: true },
+          },
+        },
+    }):null;
 
   const prevQuiz =
   user.prevQuizId

--- a/src/server/models/quizSchema.ts
+++ b/src/server/models/quizSchema.ts
@@ -36,6 +36,9 @@ export const RandomQuizSchema = QuizSchema.extend({
   prevAnswer: z.string().openapi({
     example: "yes"
   }),
+  prevQuiz: z.string().nullable().openapi({
+    example: "前のクイズの問題文"
+  }),
 })
 
 export const CreateQuizSchema = z.object({

--- a/src/server/models/quizSchema.ts
+++ b/src/server/models/quizSchema.ts
@@ -36,7 +36,7 @@ export const RandomQuizSchema = QuizSchema.extend({
   prevAnswer: z.string().openapi({
     example: "yes"
   }),
-  prevQuiz: z.string().nullable().openapi({
+  prevQuiz: z.string().openapi({
     example: "前のクイズの問題文"
   }),
 })


### PR DESCRIPTION
## 実装内容
ホーム画面に前回の問題文と正答をShadcn/uiで実装。加えて、作問エリアのデフォルトの高さをplaceholderに合うように調節。
## スクショ
<img width="858" height="550" alt="スクリーンショット 2025-07-28 21 09 13" src="https://github.com/user-attachments/assets/e9ceb751-23cb-4cad-b8fc-3e14381cb5aa" />

<img width="756" height="269" alt="スクリーンショット 2025-07-28 21 09 34" src="https://github.com/user-attachments/assets/7c6d6262-7519-4fad-864b-c60916318822" />

## issue
close 

## 懸念点
